### PR TITLE
[Doc][Main]Add --headless parameter to node1 startup args in vllm multi-node deployment

### DIFF
--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -79,6 +79,7 @@ vllm serve meituan-longcat/LongCat-Flash-Chat \
 vllm serve meituan-longcat/LongCat-Flash-Chat \
    --trust-remote-code \
    --tensor-parallel-size 8 \
+   --headless \
    --data-parallel-size 2 \
    --data-parallel-size-local 1 \
    --data-parallel-start-rank 1 \


### PR DESCRIPTION
In the vllm multi-node deployment scenario, the --headless parameter should be added to the vllm startup parameters of node1.